### PR TITLE
Adding async array prototype methods 

### DIFF
--- a/array/HOF.js
+++ b/array/HOF.js
@@ -1,0 +1,33 @@
+const awhile = require('@awhile/awhile');
+const { typeCheckIterator } = require('./helpers');
+const aForEach = require('./aForEach').default;
+
+exports.mapHOF = function mapHOF(iterator) {
+  return async function(array, callback) {
+    let result;
+    async function _callback(current, index, array) {
+      const callbackReturn = await callback(current, index, array);
+      result = iterator(callbackReturn, result, current);
+    }
+
+    await aForEach(array, _callback);
+    return result;
+  }
+}
+
+exports.reduceHOF = function reduceHOF(iterator) {
+  return async function(array, callback, initialValue = undefined) {
+    typeCheckIterator(array, callback);
+    let result = initialValue;
+    if (result === undefined) result = array[0];
+    if (result === undefined) throw Error('if array is empty, an initial value must be provided')
+
+    async function _callback(current, index, array) {
+      const callbackReturn = await callback(result, current, index, array)
+      result = iterator(callbackReturn, current, result)
+    }
+
+    await aForEach(array, _callback)
+    return result;
+  }
+}

--- a/array/aForEach.js
+++ b/array/aForEach.js
@@ -1,0 +1,6 @@
+const _aForEach = require('./prototypes')._aForEach
+const { basicIterator, breakIf } = require('./iteratorCreators')
+
+const aForEach = basicIterator(breakIf(_aForEach));
+
+exports.default = aForEach;

--- a/array/helpers.js
+++ b/array/helpers.js
@@ -1,0 +1,4 @@
+exports.typeCheckIterator = function typeCheckIterator(array, callback) {
+  if (!Array.isArray(array)) throw Error('first argument must be an array')
+  if (typeof callback !== 'function') throw Error('second argument must be a function')
+}

--- a/array/index.js
+++ b/array/index.js
@@ -1,0 +1,31 @@
+const {
+  mapHOF,
+  reduceHOF
+} = require('./HOF');
+
+const {
+  basicIterator,
+  breakIf
+} = require('./iteratorCreators');
+
+const {
+  _aMap,
+  _aFilter,
+  _aEvery,
+  _aReduce
+} = require('./prototypes');
+
+const aForEach = require('./aForEach').default;
+
+const aMap = basicIterator(mapHOF(_aMap))
+const aFilter = basicIterator(mapHOF(_aFilter));
+const aEvery = basicIterator(breakIf(_aEvery));
+const aReduce = reduceHOF(_aReduce);
+
+module.exports = {
+  aForEach,
+  aMap,
+  aFilter,
+  aEvery,
+  aReduce,
+}

--- a/array/iteratorCreators.js
+++ b/array/iteratorCreators.js
@@ -1,0 +1,36 @@
+const awhile = require('@awhile/awhile');
+const { typeCheckIterator } = require('./helpers')
+
+exports.basicIterator = function basicIterator(iterator) {
+  return async function arrayProtoGeneric(array, callback, context) {
+    typeCheckIterator(array, callback);
+    if (context) callback = callback.bind(context);
+
+    return iterator(array, callback, context);
+  }
+}
+
+exports.breakIf = function breakIf(iterator) {
+  return async function(array, callback, context) {
+    let index = 0;
+    let cBreak = false;
+    let result;
+
+    function condition() {
+      return index < array.length;
+    }
+
+    async function _callback(fBreak) {
+      if (cBreak) return fBreak();
+      const current = array[index];
+      const callbackReturn = await callback(current, index, array);
+      [cBreak, result] = iterator(callbackReturn, current, result);
+      index++
+    }
+
+    const loop = new awhile(condition, _callback);
+    await loop.begin();
+
+    return result;
+  }
+}

--- a/array/package.json
+++ b/array/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@awhile/array",
+  "version": "1.0.0",
+  "description": "asynchronous implementation of array prototype methods",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/jeremygottfried/awhile.git"
+  },
+  "keywords": [
+    "async",
+    "array",
+    "loop",
+    "iteration",
+    "concurrency",
+    "promise",
+    "event",
+    "map",
+    "foreach",
+    "reduce",
+    "every",
+    "filter"
+  ],
+  "author": "Jeremy Gottfried",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/jeremygottfried/awhile/issues"
+  },
+  "homepage": "https://github.com/jeremygottfried/awhile#readme",
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^7.1.0"
+  },
+  "dependencies": {
+    "@awhile/awhile": "^1.0.4"
+  }
+}

--- a/array/prototypes.js
+++ b/array/prototypes.js
@@ -1,0 +1,24 @@
+const _aForEach = () => [false, undefined];
+
+const _aEvery = (fail) => [!fail, fail];
+
+function _aMap(element, result) {
+  if (result === undefined) result = [];
+  return [...result, element];
+}
+
+function _aFilter(pass, result, current) {
+  if (result === undefined) result = [];
+  if (pass) result = [...result, current];
+  return result;
+}
+
+const _aReduce = (acc) => acc;
+
+module.exports = {
+  _aForEach,
+  _aEvery,
+  _aMap,
+  _aFilter,
+  _aReduce
+};

--- a/array/test.js
+++ b/array/test.js
@@ -1,0 +1,130 @@
+var should = require('chai').should();
+var expect = require('chai').expect;
+const {
+  aForEach,
+  aMap,
+  aFilter,
+  aEvery,
+  aReduce,
+} = require('./index.js');
+
+function sleep(ms) {
+  return new Promise(
+    resolve => setTimeout(
+      () => resolve(), ms
+    )
+  )
+}
+
+function nArray(n) {
+  const array = [];
+  for (let i = 0; i < n; i++) {
+    array.push(i);
+  }
+  return array;
+}
+
+
+describe('array', function() {
+  describe('aForEach', function() {
+    it('executes an operation for every element in an array', async function() {
+      const array = ['t', 'e', 's', 't'];
+      let result = '';
+      function callback(current) {
+        result += current;
+      }
+
+      await aForEach(array, callback);
+      result.should.equal('test');
+
+    })
+
+   it('executes async operations on an array in order', async function() {
+     const timeArray = [1, 4, 2, 5];
+     let result = '';
+     async function callback(time) {
+       await sleep(time);
+       result += time;
+     }
+
+     await aForEach(timeArray, callback);
+     result.should.equal('1425')
+   })
+
+   it('should not block the main thread', async function() {
+     const largeArray = nArray(100);
+     const result = [];
+     function callback(current) {
+       result.push(current)
+     }
+     aForEach(largeArray, callback);
+     result.length.should.equal(1);
+     await sleep(200);
+     result.length.should.equal(100);
+   })
+
+   it('accepts a context argument', async function() {
+     const arr = ['a', 'b']
+     let result;
+
+     function callback() {
+       result = this.length;
+     }
+
+     await aForEach(arr, callback, arr);
+     result.should.equal(2);
+   })
+
+   it('receives index and array as extra arguments', async function() {
+     const arr = ['a', 'b']
+     let result = '';
+
+     function callback(current, index, array) {
+       result = result + array.join('') + index;
+     }
+
+     await aForEach(arr, callback);
+     result.should.equal('ab0ab1')
+   })
+  })
+
+  describe('aMap', function() {
+    it('returns a new array after executing an operation on each element', async function() {
+      const arr = [0,1,2,3]
+
+      function callback(current) {
+        return current + 1;
+      }
+      const result = await aMap(arr, callback);
+      result.join('').should.equal('1234')
+    })
+
+    it('returns a new array after executing async operation on each element in order', async function() {
+      const arr = [10,5,8,2]
+
+      async function callback(time) {
+        await sleep(time);
+        return time * time;
+      }
+      const result = await aMap(arr, callback);
+      result.join(',').should.equal('100,25,64,4')
+    })
+
+    it('should not block the main thread', async function() {
+      const largeArray = nArray(100);
+      let result = [];
+
+      function callback(current) {
+        return current;
+      }
+      aMap(largeArray, callback).then(res => result = res);
+      result.length.should.equal(0);
+      await sleep(200);
+      result.length.should.equal(100);
+    })
+
+    it('accepts a context argument', async function() {
+      
+    })
+  })
+})


### PR DESCRIPTION
## Objective

Add async methods that replicate array prototype iterators. 
- aForEach
- aMap
- aReduce
- aFilter
- aEvery

These methods will have similar functionality to array prototypes iterators, but they can additionally carry out asynchronous tasks in order. 

For example, the `aReduce` method will allow you to reduce an array asynchronously, which is currently not possible with array prototype.
```js
const arr = [0,1,2,3];

async function callback(acc, current) {
  await new Promise(resolve => setTimeout(resolve, 0));
  return acc + current;
}

const reduce = aReduce(arr, callback); // => 6
```
## Why

Most native array prototype iterators do not work well with async. 
With `forEach`, you can schedule async tasks, but they will not occur in order. 
With `map`, it returns an array of promises.
`reduce` doesn't work at all with async values.

## User Experience

These methods will give users a more familiar interface for working with asynchronous iteration. Most javascript developers don't work with `while` loops on a regular basis.