### PR TITLE
Use generator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 "use strict";
 
-module.exports = function awhile(condition, callback) {
+const createVirtualThread = require('./src/createVirtualThread');
+
+exports.default = function awhile(condition, callback) {
   if (condition !== true && typeof condition !== 'function') throw Error('condition must be true or a function')
   let _break = false;
 
@@ -8,19 +10,20 @@ module.exports = function awhile(condition, callback) {
     _break = true;
   }
 
-  function begin() {
-    if (_break) return;
-    if (typeof condition === 'function' && !condition()) return;
-    return new Promise(async (resolve) => {
-      await callback(fBreak);
-      setTimeout(() => {
-        resolve();
-      }, 0);
-    }).then(begin)
-  }
+  const loop = (function* () {
+    while(true) {
+      if (_break) break;
+      if (typeof condition === 'function' && !condition()) break;
+      yield callback(fBreak);
+    }
+  })()
+
+  const begin = createVirtualThread(loop);
 
   this.break = fBreak;
   this.begin = begin;
 
   return Object.freeze(this);
 }
+
+exports.createVirtualThread = createVirtualThread;

--- a/src/createVirtualThread.js
+++ b/src/createVirtualThread.js
@@ -1,0 +1,13 @@
+module.exports = function createVirtualThread(generator) {
+  return function begin(arg) {
+    const current = generator.next(arg)
+    const promise = current.value;
+    if (current.done) return;
+    return new Promise(async (resolve) => {
+      await promise;
+      setTimeout(() => {
+        resolve();
+      }, 0);
+    }).then(begin);
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const awhile = require('./index.js');
+const awhile = require('./index.js').default;
 var should = require('chai').should();
 var expect = require('chai').expect;
 
@@ -40,7 +40,7 @@ describe('awhile', function() {
       return index < arr.length
     }
     await new awhile(condition, callback).begin();
-    await new Promise((resolve) => setTimeout(() => resolve(), 1000))
+    await new Promise((resolve) => setTimeout(() => resolve(), 200))
     result.should.equal('abcd');
 
   })


### PR DESCRIPTION
## Objective

Use a [generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) to separate the concerns of a virtual thread and while loop logic.

## Why

 In theory, `awhile` module should only have to handle the basic logic of a while loop. The thread logic can be reused for many different types of iterators, such as `for`, `do while`, `until`, etc. This will improve readability and modularity.

## User Experience 

This shouldn't have any effect on the actual runtime. The black box will behave in exactly the same way. This is because browsers [actually transpile `async/await` to generators + promises](https://tc39.es/ecmascript-asyncawait/).