### PR TITLE
Performance option

### DIFF
--- a/awhile/index.js
+++ b/awhile/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const createVirtualThread = require('./src/createVirtualThread');
+const createVirtualThread = require('./src/createVirtualThread').default;
+const createVirtualThread_SafetyOff = require('./src/createVirtualThread').createVirtualThread_SafetyOff
 
 exports.default = function awhile(condition, callback) {
   if (condition !== true && typeof condition !== 'function') throw Error('condition must be true or a function')
@@ -18,7 +19,10 @@ exports.default = function awhile(condition, callback) {
     }
   })()
 
-  const begin = createVirtualThread(loop);
+  const begin = function(safetyOff=false) {
+    if (safetyOff) return createVirtualThread_SafetyOff(loop)()
+    else return createVirtualThread(loop)();
+  }
 
   this.break = fBreak;
   this.begin = begin;

--- a/awhile/package.json
+++ b/awhile/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.4",
   "description": "Allows you to run  while loops concurrently and never block the main thread",
   "main": "index.js",
-  "repository" : {
-    "type" : "git",
+  "repository": {
+    "type": "git",
     "url": "ssh://git@github.com:jeremygottfried/awhile.git"
   },
   "scripts": {
@@ -21,7 +21,8 @@
   "license": "ISC",
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^7.1.0"
+    "mocha": "^7.1.0",
+    "node-fetch": "^2.6.0"
   },
   "dependencies": {}
 }

--- a/awhile/src/createVirtualThread.js
+++ b/awhile/src/createVirtualThread.js
@@ -1,4 +1,4 @@
-module.exports = function createVirtualThread(generator) {
+exports.default = function createVirtualThread(generator) {
   return function begin(arg) {
     const current = generator.next(arg)
     const promise = current.value;
@@ -9,5 +9,14 @@ module.exports = function createVirtualThread(generator) {
         resolve();
       }, 0);
     }).then(begin);
+  }
+}
+
+exports.createVirtualThread_SafetyOff = function createVirtualThread_SafetyOff(generator) {
+  return function begin(arg) {
+    const current = generator.next(arg)
+    const promise = current.value;
+    if (current.done) return;
+    return Promise.resolve(promise).then(begin);
   }
 }

--- a/awhile/test.js
+++ b/awhile/test.js
@@ -1,6 +1,7 @@
 const awhile = require('./index.js').default;
-var should = require('chai').should();
-var expect = require('chai').expect;
+const should = require('chai').should();
+const expect = require('chai').expect;
+const fetch = require("node-fetch");
 
 describe('awhile', function() {
   it('should continue loop until a condition is met', async function() {
@@ -109,7 +110,7 @@ describe('awhile', function() {
     let variable;
 
     async function callback() {
-       await new Promise(resolve => setTimeout(() => resolve()))
+       const res = await fetch('http://google.com')
        return 'test';
     }
 

--- a/awhile/test.js
+++ b/awhile/test.js
@@ -11,13 +11,16 @@ describe('awhile', function() {
     function condition() {
       return count < 5;
     }
-    await new awhile(condition, callback).begin();
+    await new awhile(condition, callback).begin(true);
+    count.should.equal(5);
+    count = 0;
+    await new awhile(condition, callback).begin()
     count.should.equal(5);
   })
 
   it('should carry out asynchronous tasks in order', async function() {
-    let index = 0
-    let result = ''
+    let index = 0;
+    let result = '';
     function resolveStr(str, time) {
       return new Promise(resolve => setTimeout(() => resolve(str), time))
     }
@@ -39,10 +42,12 @@ describe('awhile', function() {
     function condition() {
       return index < arr.length
     }
-    await new awhile(condition, callback).begin();
-    await new Promise((resolve) => setTimeout(() => resolve(), 200))
+    await new awhile(condition, callback).begin(true);
     result.should.equal('abcd');
-
+    index = 0;
+    result = '';
+    await new awhile(condition, callback).begin();
+    result.should.equal('abcd');
   })
 
   it('should break if break function is called inside callback', async function() {
@@ -61,8 +66,11 @@ describe('awhile', function() {
     }
 
     await new awhile(condition, callback).begin();
-    clearTimeout(timeout);
     count.should.equal(10)
+    count = 0;
+    await new awhile(condition, callback).begin(true);
+    count.should.equal(10)
+    clearTimeout(timeout);
   })
 
   it('should break if break function is called outside callback', async function() {
@@ -85,11 +93,36 @@ describe('awhile', function() {
     const interval = setInterval(() => {
       if (count > 5) loop.break();
     }, 1)
-
     await loop.begin();
-    clearTimeout(timeout);
-    clearInterval(interval);
     expect(count).to.be.above(5)
+    clearInterval(interval);
+
+    count = 0;
+    const loop2 = new awhile(condition, callback);
+    const interval2 = setInterval(() => {
+      if (count > 5) loop2.break();
+    }, 1)
+    clearInterval(interval2);
+    clearTimeout(timeout);
+  })
+  it('should mostly not block the main thread if true is passed to begin function', async function() {
+    let variable;
+
+    async function callback() {
+       await new Promise(resolve => setTimeout(() => resolve()))
+       return 'test';
+    }
+
+    const loop = new awhile(true, callback);
+    loop.begin(true);
+    await new Promise((resolve) => {
+      setTimeout(() => {
+        variable = 'test';
+        resolve();
+      }, 0)
+    })
+    variable.should.equal('test');
+    loop.break();
   })
 
   it('should not block main thread', async function() {


### PR DESCRIPTION
## Objective

Adds a more performant option for running `awhile` loops.
```js
const loop = new awhile(condition, callback);
loop.begin(true);
```
Passing `true` to `begin` results in more performant promise chains, but will turn off safety measures protecting the main thread.

## Why

Normally, the browser batches chains of resolved promises in what's commonly referred to as *microtasks*. 
Some promises are resolved immediately, and those are added to the current batch of microtasks. 

For example, this function turns into an immediately resolved promise:
```js
async function foo() {
  return ''bar"
}
```
An infinite chain of these types of promises will result in an infinite batch of microtasks, essentially blocking the main thread indefinitely.

For example, this would normally block the main thread indefinitely: 
```js
async function callback() {
  return ''bar"
}

new awhile(true, callback).begin();
```

The current implementation of `awhile` adds a safety measure to prevent blocking the microtask queue.
```js
    return new Promise(async (resolve) => {
      await promise;
      setTimeout(() => {
        resolve();
      }, 0);
    }).then(begin);
```
`setTimeout` is treated as a normal task on the main thread. As a result, `setTimeout` disrupts the microtask batching system, forcing the main thread to accept new tasks on its stack. 

The drawback to `setTimeout` is that it mildly hurts performance. Every time setTimeout is called, then the next task is differed for another tick of the event loop.

If you remove `setTimeout` and immediately resolve the promise, it allows the normal browser mechanism of batching promises to kick in, which improves performance for larger promise chains.
It will not block the main thread for longer than a single batch of micro tasks. As long as the callback carries out actual asynchronous behavior.